### PR TITLE
Downgrade the PHPStan action version

### DIFF
--- a/.github/actions/php-test/action.yml
+++ b/.github/actions/php-test/action.yml
@@ -44,7 +44,7 @@ runs:
   steps:
     - name: 'PHPStan'
       if: ${{ inputs.phpstan-enable == 'true' && inputs.php-version == inputs.phpstan-php-version }}
-      uses: php-actions/phpstan@v3
+      uses: php-actions/phpstan@v3.0.2
       with:
         configuration: ${{ inputs.phpstan-config }}
         memory_limit: ${{ inputs.phpstan-memory-limit }}


### PR DESCRIPTION
The latest update to this action seems to have broken our CI.
https://github.com/php-actions/phpstan/releases/tag/v3.0.3

I haven no idea why though as none of the listed changes should be impacting us, but this PR downgrades it as a workaround.