### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,5 +1,7 @@
 name: Lint GitHub Actions workflows
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   actionlint:


### PR DESCRIPTION
Potential fix for [https://github.com/FOSSBilling/.workflows/security/code-scanning/1](https://github.com/FOSSBilling/.workflows/security/code-scanning/1)

To fix the problem, explicitly define restricted `GITHUB_TOKEN` permissions for this workflow or job so that GitHub does not fall back to broader repository defaults. Since this workflow only checks out code and runs a linter, it only needs read access to repository contents.

The best fix without changing existing functionality is to add a `permissions` block that grants `contents: read`. This can be defined at the workflow (top) level so it applies to all jobs in this workflow. Concretely, in `.github/workflows/actionlint.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block. No imports or additional methods are needed, as this is a YAML configuration change only. All existing steps and behavior remain unchanged; only the implicit `GITHUB_TOKEN` permissions are tightened.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
